### PR TITLE
test: add koa, fastify, and nestjs to regression suite

### DIFF
--- a/lib/test-suite.ts
+++ b/lib/test-suite.ts
@@ -165,8 +165,7 @@ export namespace Step {
         command: string | string[] | Step,
         rest: Options = {}
     ): Step {
-        if (typeof command === 'object' && !Array.isArray(command))
-            return command
+        if (Step.is(command)) return command
         return {
             name: rest.name,
             run: Array.isArray(command)

--- a/src/buildkite/render.ts
+++ b/src/buildkite/render.ts
@@ -68,7 +68,7 @@ export class PipelineFactory {
             : testCase.name
         const scriptLines = shell.renderTestCase(testCase)
         const script = /* sh */ `
-${testCase.failing ? '' : 'set -e'}
+${testCase.failing ? 'unset -e' : 'set -e'}
 ${this.beforeEachCase.join('\n')}
 ${scriptLines.join('\n')}
 `.trim()

--- a/src/buildkite/render.ts
+++ b/src/buildkite/render.ts
@@ -1,6 +1,6 @@
 import { Pipeline } from '@buildkite/buildkite-sdk'
 import type { GroupStep } from '@buildkite/buildkite-sdk'
-import type { PurpleStep } from '@buildkite/buildkite-sdk/src/schema'
+import { ConcurrencyMethod, type PurpleStep } from '@buildkite/buildkite-sdk/src/schema'
 import type { Context, EcosystemSuite, TestCase } from '../../lib'
 import { TestSuite } from '../../lib/test-suite'
 import * as shell from '../shell'
@@ -80,6 +80,7 @@ ${scriptLines.join('\n')}
             env: testCase.env,
             command: script,
             concurrency_group: this.getConcurrencyKey(testCase, suiteName),
+            concurrency_method: ConcurrencyMethod.Eager,
             concurrency: 1,
         }
     }

--- a/src/buildkite/render.ts
+++ b/src/buildkite/render.ts
@@ -68,16 +68,27 @@ export class PipelineFactory {
             : testCase.name
         const scriptLines = shell.renderTestCase(testCase)
         const script = /* sh */ `
-${testCase.failing ? 'unset -e' : 'set -e'}
+${testCase.failing ? 'set +e' : 'set -e'}
 ${this.beforeEachCase.join('\n')}
 ${scriptLines.join('\n')}
 `.trim()
+
 
         return {
             label,
             skip: testCase.skip,
             env: testCase.env,
             command: script,
+            concurrency_group: this.getConcurrencyKey(testCase, suiteName),
+            concurrency: 1,
         }
+    }
+
+    private getConcurrencyKey(testCase: TestCase, suiteName?: string): string {
+        const { BUILDKITE_BRANCH: branch = 'main' } = process.env
+        var key = `ecosystem-ci`
+        if (suiteName) key += `-${suiteName}`
+        key += `-${testCase.name}-${branch}`
+        return key
     }
 }

--- a/src/buildkite/render.ts
+++ b/src/buildkite/render.ts
@@ -1,6 +1,9 @@
 import { Pipeline } from '@buildkite/buildkite-sdk'
 import type { GroupStep } from '@buildkite/buildkite-sdk'
-import { ConcurrencyMethod, type PurpleStep } from '@buildkite/buildkite-sdk/src/schema'
+import {
+    ConcurrencyMethod,
+    type PurpleStep,
+} from '@buildkite/buildkite-sdk/src/schema'
 import type { Context, EcosystemSuite, TestCase } from '../../lib'
 import { TestSuite } from '../../lib/test-suite'
 import * as shell from '../shell'
@@ -72,7 +75,6 @@ ${testCase.failing ? 'set +e' : 'set -e'}
 ${this.beforeEachCase.join('\n')}
 ${scriptLines.join('\n')}
 `.trim()
-
 
         return {
             label,

--- a/src/buildkite/render.ts
+++ b/src/buildkite/render.ts
@@ -68,7 +68,7 @@ export class PipelineFactory {
             : testCase.name
         const scriptLines = shell.renderTestCase(testCase)
         const script = /* sh */ `
-set -e
+${testCase.failing ? '' : 'set -e'}
 ${this.beforeEachCase.join('\n')}
 ${scriptLines.join('\n')}
 `.trim()

--- a/suites/foundation-regression.ts
+++ b/suites/foundation-regression.ts
@@ -24,6 +24,7 @@ export default installAndTest('foundation regression', {
     fastify: {
         repository: 'https://github.com/fastify/fastify.git',
         postinstall: ({ bun }) => `${bun} i typescript`,
+        install: 'npm install',
         test: 'unit',
     },
     koa: {

--- a/suites/foundation-regression.ts
+++ b/suites/foundation-regression.ts
@@ -36,6 +36,7 @@ export default installAndTest('foundation regression', {
     },
     elysia: {
         repository: 'https://github.com/elysiajs/elysia.git',
+        install: 'npm install',
         postinstall: ({ bun }) => `${bun} run build`,
     },
     nestjs: {

--- a/suites/foundation-regression.ts
+++ b/suites/foundation-regression.ts
@@ -23,7 +23,7 @@ export default installAndTest('foundation regression', {
     },
     fastify: {
         repository: 'https://github.com/fastify/fastify.git',
-        postinstall: () => `npm i -g typescript`,
+        postinstall: ({ bun }) => `${bun} i typescript`,
         test: 'unit',
     },
     koa: {

--- a/suites/foundation-regression.ts
+++ b/suites/foundation-regression.ts
@@ -13,6 +13,8 @@ export default installAndTest('foundation regression', {
         ref: 'master',
         test: `--bun run test`,
         failing: true,
+        // takes like an hour b/c of bug in setTimeout or something
+        skip: true,
         // test: 'test test/*.js',
         // preload: [
         //     import.meta.require.resolve('@shim/mocha'),
@@ -21,7 +23,9 @@ export default installAndTest('foundation regression', {
     },
     fastify: {
         repository: 'https://github.com/fastify/fastify.git',
+        postinstall: () => `npm i -g typescript`,
         test: 'unit',
+
     },
     koa: {
         repository: 'https://github.com/koajs/koa',

--- a/suites/foundation-regression.ts
+++ b/suites/foundation-regression.ts
@@ -21,7 +21,7 @@ export default installAndTest('foundation regression', {
     },
     fastify: {
         repository: 'https://github.com/fastify/fastify.git',
-        test: 'unit'
+        test: 'unit',
     },
     koa: {
         repository: 'https://github.com/koajs/koa',
@@ -71,9 +71,9 @@ export default installAndTest('foundation regression', {
         },
     },
     prisma: {
-        preinstall: ({ isLocal, bun }) => isLocal ? undefined : `${bun} i -g pnpm`,
+        preinstall: ({ isLocal, bun }) =>
+            isLocal ? undefined : `${bun} i -g pnpm`,
         repository: 'https://github.com/prisma/prisma',
         postinstall: ({ bun }) => `pnpm i && ${bun} run build`,
-
-    }
+    },
 })

--- a/suites/foundation-regression.ts
+++ b/suites/foundation-regression.ts
@@ -25,7 +25,6 @@ export default installAndTest('foundation regression', {
         repository: 'https://github.com/fastify/fastify.git',
         postinstall: () => `npm i -g typescript`,
         test: 'unit',
-
     },
     koa: {
         repository: 'https://github.com/koajs/koa',

--- a/suites/foundation-regression.ts
+++ b/suites/foundation-regression.ts
@@ -81,5 +81,6 @@ export default installAndTest('foundation regression', {
             isLocal ? undefined : `${bun} i -g pnpm`,
         install: 'pnpm i',
         postinstall: ({ bun }) => `pnpm i && ${bun} run build`,
+        skip: true, // relies on gh actions. TODO: polyfill w buildkite env vars
     },
 })

--- a/suites/foundation-regression.ts
+++ b/suites/foundation-regression.ts
@@ -8,15 +8,6 @@
 import { installAndTest } from '../lib'
 
 export default installAndTest('foundation regression', {
-    /**
-     * it's got like 116m downloads
-     * https://www.npmjs.com/package/minipass
-     */
-    minipass: {
-        repository: 'https://github.com/isaacs/minipass',
-        test: '--bun tap',
-        failing: true,
-    },
     express: {
         repository: 'https://github.com/expressjs/express',
         ref: 'master',
@@ -28,9 +19,37 @@ export default installAndTest('foundation regression', {
         //     './test/support/env.js',
         // ],
     },
+    fastify: {
+        repository: 'https://github.com/fastify/fastify.git',
+        test: 'unit'
+    },
+    koa: {
+        repository: 'https://github.com/koajs/koa',
+        ref: 'master',
+    },
+    hono: {
+        repository: 'https://github.com/honojs/hono',
+        test: 'test:bun',
+    },
     elysia: {
         repository: 'https://github.com/elysiajs/elysia.git',
         postinstall: ({ bun }) => `${bun} run build`,
+    },
+    nestjs: {
+        repository: 'https://github.com/nestjs/nest.git',
+        ref: 'master',
+        postinstall: ({ bun }) => `${bun} run build`,
+        test: 'test',
+        failing: true,
+    },
+    /**
+     * it's got like 116m downloads
+     * https://www.npmjs.com/package/minipass
+     */
+    minipass: {
+        repository: 'https://github.com/isaacs/minipass',
+        test: '--bun tap',
+        failing: true,
     },
 
     // these guys use bun
@@ -40,10 +59,6 @@ export default installAndTest('foundation regression', {
         test: 'test:bun',
         postinstall: ({ bun }) => `${bun} run build`,
         failing: true,
-    },
-    hono: {
-        repository: 'https://github.com/honojs/hono',
-        test: 'test:bun',
     },
     socks: {
         repository: 'https://github.com/JoshGlazebrook/socks',
@@ -55,4 +70,10 @@ export default installAndTest('foundation regression', {
             NODE_ENV: 'test',
         },
     },
+    prisma: {
+        preinstall: ({ isLocal, bun }) => isLocal ? undefined : `${bun} i -g pnpm`,
+        repository: 'https://github.com/prisma/prisma',
+        postinstall: ({ bun }) => `pnpm i && ${bun} run build`,
+
+    }
 })

--- a/suites/foundation-regression.ts
+++ b/suites/foundation-regression.ts
@@ -62,6 +62,7 @@ export default installAndTest('foundation regression', {
         test: 'test:bun',
         postinstall: ({ bun }) => `${bun} run build`,
         failing: true,
+        skip: true, // hangs in CI
     },
     socks: {
         repository: 'https://github.com/JoshGlazebrook/socks',
@@ -74,9 +75,10 @@ export default installAndTest('foundation regression', {
         },
     },
     prisma: {
+        repository: 'https://github.com/prisma/prisma',
         preinstall: ({ isLocal, bun }) =>
             isLocal ? undefined : `${bun} i -g pnpm`,
-        repository: 'https://github.com/prisma/prisma',
+        install: 'pnpm i',
         postinstall: ({ bun }) => `pnpm i && ${bun} run build`,
     },
 })

--- a/suites/foundation-regression.ts
+++ b/suites/foundation-regression.ts
@@ -23,9 +23,8 @@ export default installAndTest('foundation regression', {
     },
     fastify: {
         repository: 'https://github.com/fastify/fastify.git',
-        postinstall: ({ bun }) => `${bun} i typescript`,
-        install: 'npm install',
-        test: 'unit',
+        test: 'test', // `bun test`
+        failing: true,
     },
     koa: {
         repository: 'https://github.com/koajs/koa',

--- a/suites/oss-apps.ts
+++ b/suites/oss-apps.ts
@@ -1,10 +1,6 @@
 import { installAndTest } from '../lib'
 
 export default installAndTest('oss applications', {
-    // AFFiNE: {
-    //     repository: 'https://github.com/toeverything/AFFiNE',
-    //     ref: 'canary',
-    // },
     'next-starter': {
         repository: 'https://github.com/Skolaczk/next-starter',
     },
@@ -14,7 +10,8 @@ export default installAndTest('oss applications', {
         install: 'pnpm install',
         preinstall: ({ isLocal, bun }) =>
             isLocal ? undefined : `${bun} install -g pnpm`,
-        failing: true, // uses pnpm workspaces
+        failing: true,
+        skip: true, // FIXME
     },
     // they use bun
     onlook: {

--- a/suites/oss-apps.ts
+++ b/suites/oss-apps.ts
@@ -11,6 +11,7 @@ export default installAndTest('oss applications', {
     remotion: {
         repository: 'https://github.com/remotion-dev/remotion',
         postinstall: ({ bun }) => `${bun} run build`,
+        install: 'pnpm install',
         preinstall: ({ isLocal, bun }) =>
             isLocal ? undefined : `${bun} install -g pnpm`,
         failing: true, // uses pnpm workspaces


### PR DESCRIPTION
- add koa, fastify, and nestjs to regression test suites
- use concurrency groups to cancel in-progress jobs
- make `install` step configurable, letting us use `pnpm install` for repos that use pnpm workspaces