### PR TITLE
fix: shim node binary before running tests

### DIFF
--- a/.buildkite/shim-node.sh
+++ b/.buildkite/shim-node.sh
@@ -1,0 +1,11 @@
+# shim-node.sh
+# creates a fake node binary and prepends it to $PATH. This way, any tests trying
+# to run `node` will fail
+
+node_dir=$(mktemp -d)
+echo "making fake node dir: $node_dir"
+echo "throw new Error('Test suite tried to use node!');" > $node_dir/node
+chmod +x $node_dir/node
+chmod a+x $node_dir/node
+echo "export PATH=\"$node_dir:\$PATH\"" >> ~/.bashrc
+export PATH="$node_dir:$PATH"

--- a/lib/install-and-test.ts
+++ b/lib/install-and-test.ts
@@ -146,10 +146,10 @@ export function installAndTest(
                     testEnv ??= {}
                     testEnv['PATH'] = pathWithShimmedNodeBin
                 } else {
-                    shimNodeStep = Step.from(
-                        ['. ./.buildkite/shim-node.sh'],
-                        { name: 'Shim node binary', key: 'shim-node' }
-                    )
+                    shimNodeStep = Step.from(['. ./.buildkite/shim-node.sh'], {
+                        name: 'Shim node binary',
+                        key: 'shim-node',
+                    })
                 }
 
                 const testCase = TestCase.from(packageName, {
@@ -167,16 +167,16 @@ export function installAndTest(
                             key: 'create-bunfig',
                         }),
                         preinstall &&
-                        Step.from(preinstall, {
-                            cwd: packageName,
-                            key: 'preinstall',
-                        }),
+                            Step.from(preinstall, {
+                                cwd: packageName,
+                                key: 'preinstall',
+                            }),
                         install,
                         postinstall &&
-                        Step.from(postinstall, {
-                            cwd: packageName,
-                            key: 'postinstall',
-                        }),
+                            Step.from(postinstall, {
+                                cwd: packageName,
+                                key: 'postinstall',
+                            }),
                         shimNodeStep,
 
                         Step.from(testStep, {

--- a/lib/install-and-test.ts
+++ b/lib/install-and-test.ts
@@ -148,8 +148,8 @@ export function installAndTest(
                     shimNodeStep = Step.from(
                         [
                             `node_dir=$(mktemp -d)`,
-                            'echo "throw new Error(\'Test suite tried to use node!\');" > ${node_dir}/node',
-                            'chmod a+x ${node_dir}/node',
+                            'echo "throw new Error(\'Test suite tried to use node!\');" > "$node_dir/node"',
+                            'chmod a+x "${node_dir}/node"',
                             'export PATH="${node_dir}:${PATH}"',
                         ],
                         { name: 'Shim node binary', key: 'shim-node' }

--- a/lib/steps.ts
+++ b/lib/steps.ts
@@ -1,4 +1,6 @@
-import { Step } from './test-suite'
+import os from 'node:os'
+import fs from 'fs'
+import { Step, type Context } from './test-suite'
 
 type Checkout = {
     repository: string
@@ -32,3 +34,11 @@ fi
         key: `checkout-${packageName}`,
     })
 }
+
+// export const stubOutNode = (ctx: Context) => {
+//    if (ctx.isLocal && ctx.runner == 'bun')
+//     const dir = fs.mkdtempSync('bun-ecosystem-ci-' + uid())
+//    }
+// }
+
+// const uid = () => Math.floor(Math.random() * 32_000).toString(16)

--- a/lib/test-suite.ts
+++ b/lib/test-suite.ts
@@ -10,7 +10,7 @@ import type { Maybe } from './types'
  * - {@link TestCase} -> job
  * - {@link Step} -> step lol
  */
-export interface Context {
+export interface Context<D = any> {
     /**
      * Are we running tests locally or in CI?
      */
@@ -20,17 +20,18 @@ export interface Context {
      * Name of bun binary. Use this instead of hardcoding `'bun'` into steps.
      */
     bun: string
+    data?: D
 }
 
-export type EcosystemSuite =
-    | TestSuite
-    | ((context: Readonly<Context>) => TestSuite | Promise<TestSuite>)
+export type EcosystemSuite<D = any> =
+    | TestSuite<D>
+    | ((context: Readonly<Context<D>>) => TestSuite<D> | Promise<TestSuite<D>>)
 
-export interface TestSuite {
+export interface TestSuite<D = any> {
     name?: string
     cases: TestCase[]
-    beforeAll?: (context: Readonly<Context>) => void | Promise<void>
-    afterAll?: (context: Readonly<Context>) => void | Promise<void>
+    beforeAll?: (context: Readonly<Context<D>>) => void | Promise<void>
+    afterAll?: (context: Readonly<Context<D>>) => void | Promise<void>
 }
 export namespace TestSuite {
     export async function reify(

--- a/src/shell.test.ts
+++ b/src/shell.test.ts
@@ -59,7 +59,7 @@ describe(renderSuite, () => {
             expect(shellcheck).toBeTruthy()
             const filename = path.join(tmpdir, 'basic-step.sh')
             await Bun.write(filename, rendered.join('\n'))
-            const result = await Bun.spawn([shellcheck!, filename], {
+            const result = await Bun.spawn([shellcheck!, '-x', filename], {
                 stdout: 'inherit',
             })
             expect(await result.exited).toBe(0)

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import type { Maybe } from '../lib/types'
 
 /**
@@ -52,3 +55,14 @@ export const toSnakeCase = (str: string): string => {
 
 export const truthy: (value: Maybe<string | false | 0>) => value is string =
     Boolean as any
+
+// const uid = (): string => Math.floor(Math.random() * 32_000).toString(16)
+
+/**
+ * Create a temporary directory
+ * @param prefix Optional prefix. 6 random characters will be appended to it.
+ * @returns absolute path to new temp dir. Promise resolves after the directory
+ * is created.
+ */
+export const tmpDir = (prefix: string = 'ecosystem-ci'): Promise<string> =>
+    fs.promises.mkdtemp(path.join(os.tmpdir(), prefix))

--- a/suites/foundation-regression.ts
+++ b/suites/foundation-regression.ts
@@ -29,7 +29,7 @@ export default installAndTest('foundation regression', {
     koa: {
         repository: 'https://github.com/koajs/koa',
         ref: 'master',
-        test: 'test'
+        test: 'test',
     },
     hono: {
         repository: 'https://github.com/honojs/hono',


### PR DESCRIPTION
## What This PR Does
Creates a fake `node` binary and prepends it to `$PATH` before running any of a package's tests. This way any attempts to use `node` will cause a test failure.